### PR TITLE
Affine Bug Fix

### DIFF
--- a/src/numanalysislib/basis/affine.py
+++ b/src/numanalysislib/basis/affine.py
@@ -1,11 +1,3 @@
-"""
-**Goal:** Handle the mapping between a "Reference Interval" (e.g., $[-1, 1]$) and a "Physical Interval" $[a, b]$.
-
-- **Methods:** - `pull_back(x)`: Maps $x \in [a, b] \to \hat{x} \in [\hat{a}, \hat{b}]$.
-  - `push_forward(hat_x)`: Maps $\hat{x} \in [\hat{a}, \hat{b}] \to x \in [a, b]$.
-- **Math:** $x = a + \frac{\hat{x} - \hat{a}}{\hat{b} - \hat{a}}(b - a)$.
-- **Note:** All other basis implementations will inherit from this class to gain domain-flexibility.
-"""
 from numanalysislib.basis._abstract import PolynomialBasis
 import numpy as np
 
@@ -14,10 +6,10 @@ class AffinePolynomialBasis(PolynomialBasis):
         """
         Initializes class mapping between [a,b] and [hat_a, hat_b]
 
-        Inputs:
-        basis: the polynomial basis to use
-        a: left endpoint of physical interval
-        b: right endpoint of physical interval
+        Args:
+            basis (PolynomialBasis): the polynomial basis to use
+            a (float): left endpoint of physical interval
+            b (float): right endpoint of physical interval
         """
         # check for endpoint ordering
         if a > b:
@@ -37,7 +29,13 @@ class AffinePolynomialBasis(PolynomialBasis):
     def evaluate_basis(self, index: int, x: np.ndarray) -> np.ndarray:
         """
         Evaluate the i-th basis function at points x.
-        phi_i(x)
+
+        Args:
+            index (int): index of basis function to evaluate
+            x (np.ndarray): position to evaluate at
+
+        Returns:
+            np.ndarray: basis function evaluated at x
         """
         x_hat = self.pull_back(x)
         x_hat_eval = self.basis.evaluate_basis(index, x_hat)
@@ -47,34 +45,39 @@ class AffinePolynomialBasis(PolynomialBasis):
     def fit(self, x_nodes: np.ndarray, y_nodes: np.ndarray) -> np.ndarray:
         """
         Computes the coefficients c such that p(x_nodes) = y_nodes.
-        Returns the coefficients array.
+        
+        Args:
+            x_nodes (np.ndarray): x positions in physical space to fit onto
+            y_nodes (np.ndarray): function values to fit to
+        
+        Returns:
+            np.ndarray: coefficients for fit basis
         """
         x_nodes_hat = self.pull_back(x_nodes)
-        y_nodes_hat = self.pull_back(y_nodes)
-        return self.basis.fit(x_nodes_hat, y_nodes_hat)
+        return self.basis.fit(x_nodes_hat, y_nodes)
 
 
-    def pull_back(self, x: float) -> float:
+    def pull_back(self, x: np.ndarray) -> np.ndarray:
         """
-        Maps $x \in [a, b] \to \hat{x} \in [\hat{a}, \hat{b}]
+        Maps x in [a, b] to hat_x in [hat_a, hat_b]
 
-        Inputs:
-        x: element of physical interval to be mapped into reference interval
+        Args:
+            x (np.ndarray): element(s) of physical interval to be mapped into reference interval
 
-        Outputs:
-        hat_x: corresponding element in reference interval
+        Returns:
+           (np.ndarray): corresponding element(s) in reference interval
         """
         return self.a_hat + (x - self.a)/(self.b - self.a)*(self.b_hat - self.a_hat)
 
-    def push_forward(self, hat_x: float) -> float:
+    def push_forward(self, hat_x: np.ndarray) -> np.ndarray:
         """
-        Maps $\hat{x} \in [\hat{a}, \hat{b}] \to x \in [a, b]$.  
+        Maps hat_x in [hat_a, hat_b] to x in [a, b].  
 
-        Inputs:
-        hat_x: element of reference interval to be mapped into physical interval
+        Args:
+            hat_x (np.ndarray): element(s) of reference interval to be mapped into physical interval
 
-        Outputs:
-        x: corresponding element in physical interval
+        Returns:
+            np.ndarray: corresponding element(s) in physical interval
         """
         return self.a + (hat_x - self.a_hat)/(self.b_hat - self.a_hat)*(self.b - self.a)
     

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -48,6 +48,18 @@ class TestAffinePower:
 
         np.testing.assert_allclose(mapped_reference_int, physical_int)
 
+    def test_fit_evaluate(self):
+        power = PowerBasis(1)
+        a = 0.0
+        b = 0.5
+        affine = AffinePolynomialBasis(power, a, b)
+        x_vals = np.array([0.0, 0.5])
+        y_vals = np.array([0.0, 0.5])
+        coeffs = affine.fit(x_vals, y_vals)
+        pred_y_vals = affine.evaluate(coeffs, x_vals)
+        
+        np.testing.assert_allclose(pred_y_vals, y_vals, atol = 1e-12)
+
     def test_bound_order_test_failure(self):
         """
         Check for failure


### PR DESCRIPTION
## Description
affine_mapper.py had a bug where it was incorrectly pulling back the y_nodes during fitting. This has been changed. Classes relying on affine_mapper should now work. Also, docstrings were updated with the new readme.
## Linked Issue
Fixes # (issue number)

## Implementation Checklist
- [x] My class inherits from `PolynomialBasis` (if applicable).
- [x] I have implemented all abstract methods (`evaluate_basis`, `fit`, etc.).
- [x] I have used `numpy` vectorization to avoid inefficient Python loops.
- [x] Documentation strings (docstrings) are provided for all public methods.

## Peer Review Checklist (To be completed by Reviewer)

### 1. Mathematical Integrity
- [ ] **Convergence:** Does the implementation maintain expected accuracy? (Checked for Runge's phenomenon or stability).
- [ ] **Edge Cases:** Does it handle single points or non-equally spaced nodes correctly?
- [ ] **Domain Mapping:** Does the class correctly map the input domain to the basis domain (e.g., [-1, 1] for Chebyshev)?

### 2. API & Style
- [ ] **Method Signatures:** Methods match the Abstract Base Class exactly.
- [ ] **Naming:** Follows `CamelCase` for classes and `snake_case` for functions/variables.
- [ ] **Clean Code:** No "magic numbers"; constants are named and explained.

### 3. Testing Quality
- [ ] **Coverage:** Unit tests cover typical usage and edge cases.
- [ ] **Precision:** Tests use `np.testing.assert_allclose` instead of `==`.
- [ ] **Validation:** There is a test proving the basis can exactly reconstruct a polynomial of its own degree.

## Screenshots / Plots