### PR TITLE
hermite, fix errors and rebase

### DIFF
--- a/src/numanalysislib/basis/affine.py
+++ b/src/numanalysislib/basis/affine.py
@@ -1,5 +1,6 @@
 from numanalysislib.basis._abstract import PolynomialBasis
 import numpy as np
+import inspect
 
 class AffinePolynomialBasis(PolynomialBasis):
     def __init__(self, basis: PolynomialBasis, a: float, b: float):
@@ -54,6 +55,16 @@ class AffinePolynomialBasis(PolynomialBasis):
             np.ndarray: coefficients for fit basis
         """
         x_nodes_hat = self.pull_back(x_nodes)
+        
+        # Add to support the coefficient scaling for Hermite basis.
+        # Pass physical interval only if the basis needs it (optional)
+        try:
+            sig = inspect.signature(self.basis.fit)
+            if "physical_interval" in sig.parameters:
+                return self.basis.fit(x_nodes_hat, y_nodes, physical_interval=(self.a, self.b))
+        except (ValueError, TypeError):
+            pass
+
         return self.basis.fit(x_nodes_hat, y_nodes)
 
 

--- a/src/numanalysislib/basis/hermite.py
+++ b/src/numanalysislib/basis/hermite.py
@@ -1,0 +1,92 @@
+"""
+Hermite cubic polynomial basis functions.
+
+p(x) = v_a * h_0(x) + d_a * h_1(x) * (b-a) + v_b * h_2(x) + d_b * h_3(x) * (b-a)
+"""
+
+import numpy as np
+
+from numanalysislib.basis._abstract import PolynomialBasis
+
+
+class HermiteBasis(PolynomialBasis):
+
+    def __init__(self):
+        super().__init__(degree=3, a=0.0, b=1.0)
+
+    def evaluate_basis(self, index: int, x: np.ndarray) -> np.ndarray:
+        """
+        Evaluate the i-th Hermite basis function at point x. 
+            h_0 = 2x^3 - 3x^2 + 1    
+            h_1 = x^3 - 2x^2 + x     
+            h_2 = -2x^3 + 3x^2       
+            h_3 = x^3 - x^2    
+
+        Parameters
+        ----------
+        index: the index associated to the basis you want to evaluate
+        x: The value of x at which to evaluate the polynomial basis.            
+
+        Returns 
+        ----------   
+        The value of the basis at x.      
+        """
+        if index < 0 or index > self.degree:
+            raise ValueError(f"Basis index {index} out of range for degree {self.degree}")
+
+        x = np.asarray(x, dtype=float)
+        x2 = x * x
+        x3 = x2 * x
+
+        if index == 0:
+            return 2.0 * x3 - 3.0 * x2 + 1.0
+        if index == 1:
+            return x3 - 2.0 * x2 + x
+        if index == 2:
+            return -2.0 * x3 + 3.0 * x2
+        if index == 3:
+            return x3 - x2
+
+    def fit(self, x_nodes: np.ndarray, y_nodes: np.ndarray, physical_interval: tuple = None) -> np.ndarray:
+        """
+        Compute coefficients from endpoint data [v_a, d_a, v_b, d_b].
+
+        Parameters
+        ----------
+        x_nodes: [a, b] defining the interval.
+        y_nodes: [v_a, d_a, v_b, d_b], where v_a and v_b are values at two endpoints, d_a and d_b are the derivatives.
+        physical_interval: Optional tuple (a, b) to specify the physical interval for scaling derivative coefficients.
+        
+        Returns
+        -------
+        Coefficients: [v_a, (b - a) * d_a, v_b, (b - a) * d_b]. 
+        """
+        x_nodes = np.asarray(x_nodes, dtype=float)
+        y_nodes = np.asarray(y_nodes, dtype=float)
+
+        if x_nodes.shape[0] != 2:
+            raise ValueError("HermiteBasis.fit expects the interval as [a, b].")
+        if y_nodes.shape[0] != self.n_dofs:
+            raise ValueError(f"HermiteBasis.fit expects {self.n_dofs} data entries [v_a, d_a, v_b, d_b].")
+
+        # Determine scaling for derivative coefficients. 
+        # If a physical interval is provided (from an Affine wrapper), use that; otherwise infer from x_nodes.
+        if physical_interval is not None:
+            a, b = physical_interval
+        else:
+            a, b = x_nodes
+
+        scale = b - a
+        if scale <= 0.0:
+            raise ValueError("Interval endpoints must satisfy b > a.")
+
+        v_a, d_a, v_b, d_b = y_nodes
+
+        coefficients = np.array(
+            [v_a, scale * d_a, v_b, scale * d_b],
+            dtype=float,
+        )
+
+        return coefficients
+    
+    # Use the default evaluate method from the abstract class

--- a/src/numanalysislib/basis/hermite.py
+++ b/src/numanalysislib/basis/hermite.py
@@ -40,11 +40,11 @@ class HermiteBasis(PolynomialBasis):
 
         if index == 0:
             return 2.0 * x3 - 3.0 * x2 + 1.0
-        if index == 1:
+        elif index == 1:
             return x3 - 2.0 * x2 + x
-        if index == 2:
+        elif index == 2:
             return -2.0 * x3 + 3.0 * x2
-        if index == 3:
+        elif index == 3:
             return x3 - x2
 
     def fit(self, x_nodes: np.ndarray, y_nodes: np.ndarray, physical_interval: tuple = None) -> np.ndarray:

--- a/tests/test_hermite_basis.py
+++ b/tests/test_hermite_basis.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+
+from numanalysislib.basis.affine import AffinePolynomialBasis
+from numanalysislib.basis.hermite import HermiteBasis
+
+
+class TestHermiteBasis:
+    def test_evaluate_basis_endpoints(self):
+        """
+        Verify that the Hermite basis functions satisfy the expected endpoint conditions:
+            h_0 = 2t^3 - 3t^2 + 1
+            h_2 = -2t^3 + 3t^2
+            h_1 = t^3 - 2t^2 + t
+            h_3 = t^3 - t^2
+        At t=0: h_0=1, h_1=0, h_2=0, h_3=0
+        At t=1: h_0=0, h_1=0, h_2=1, h_3=0
+        """
+
+        basis = HermiteBasis()
+        t = np.array([0.0, 1.0])
+
+        h0 = basis.evaluate_basis(0, t)
+        h1 = basis.evaluate_basis(1, t)
+        h2 = basis.evaluate_basis(2, t)
+        h3 = basis.evaluate_basis(3, t)
+
+        np.testing.assert_allclose(h0, [1.0, 0.0]) 
+        np.testing.assert_allclose(h1, [0.0, 0.0]) 
+        np.testing.assert_allclose(h2, [0.0, 1.0]) 
+        np.testing.assert_allclose(h3, [0.0, 0.0])
+
+    def test_fit_scales_derivatives(self):
+        """
+        Verify the fit method correctly scales derivative coefficients based on the interval length.
+        """
+        basis = HermiteBasis()
+        x_nodes = np.array([2.0, 5.0])  
+        y_nodes = np.array([1.0, 2.0, 3.0, 4.0])  # v_a, d_a, v_b, d_b
+
+        coeffs = basis.fit(x_nodes, y_nodes)
+        # Expected coefficients: [v_a, (b - a) * d_a, v_b, (b - a) * d_b]
+        expected = np.array([1.0, 6.0, 3.0, 12.0])  
+
+        np.testing.assert_allclose(coeffs, expected)
+
+    def test_evaluate_polynomial(self):
+        """
+        Verify the evaluate method.
+        """
+        basis = HermiteBasis()
+        coeffs = np.array([1.0, 0.0, 2.0, 0.0])  # linear shape from 1 to 2
+
+        t = np.array([0.0, 0.5, 1.0])
+        values = basis.evaluate(coeffs, t)
+
+        # Expected values: at t=0 -> 1.0, at t=0.5 -> 1.5, at t=1.0 -> 2.0
+        np.testing.assert_allclose(values, [1.0, 1.5, 2.0])
+
+    def test_invalid_basis_index(self):
+        basis = HermiteBasis()
+        with pytest.raises(ValueError):
+            # index 4 is out of range
+            basis.evaluate_basis(4, np.array([0.0]))
+
+    def test_coefficient_length(self):
+        basis = HermiteBasis()
+        # example of wrong coefficient array: only 3 coefficients instead of 4
+        bad_coeffs = np.array([1.0, 2.0, 3.0])  
+        with pytest.raises(ValueError):
+            basis.evaluate(bad_coeffs, np.array([0.0]))
+
+    def test_affine_coefficients(self):
+        """
+        Hermite coefficients computed on a physical interval should evaluate
+        correctly when wrapped by AffinePolynomialBasis.
+        """
+        basis = HermiteBasis()
+        # Physical interval
+        a = 2.0
+        b = 5.0
+        
+
+        # Linear function on [2, 5]: f(x) = 1 + (x-2)/3
+        v_a = 1.0
+        v_b = 2.0
+        d_a = d_b = 1.0 / 3.0  # physical derivatives
+
+        affine = AffinePolynomialBasis(basis, a=a, b=b)
+        coeffs_hat = affine.fit(np.array([a, b]), np.array([v_a, d_a, v_b, d_b]))
+
+        np.testing.assert_allclose(
+            coeffs_hat,
+            np.array([1.0, 1.0, 2.0, 1.0]),
+        )
+
+    def test_affine_evaluate_points(self):
+        """
+        Test that the affine wrapper correctly evaluates the Hermite polynomial at points in the physical interval.
+        """
+        
+        basis = HermiteBasis()
+        # Physical interval
+        a = 2.0
+        b = 5.0
+        # Linear function on [2, 5]: f(x) = 1 + (x-2)/3
+        v_a = 1.0
+        v_b = 2.0
+        d_a = d_b = 1.0 / 3.0  # physical derivatives
+
+        affine = AffinePolynomialBasis(basis, a=a, b=b)
+        coeffs_hat = affine.fit(np.array([a, b]), np.array([v_a, d_a, v_b, d_b]))
+
+        x_phys = np.array([a, 3.0, 4.0, b])
+        expected = np.array([1.0, 1+1.0/3.0, 1+2.0/3.0, 2.0])
+        values = affine.evaluate(coeffs_hat, x_phys)
+        np.testing.assert_allclose(values, expected)


### PR DESCRIPTION
## Description

Hermite basis which reconstruct a cubic polynomial using the values and derivatives at the endpoints of a given interval. Added a few lines in Affine.py to feed in the physical interval in the basis.fit function in order to account for the Jacobian $1/(b-a)$ when computing coefficients.

Reopened this new pull request to fix rebase issue and errors from previous commits.

## Linked Issue
Fixes # 14

## Implementation Checklist
- [x] My class inherits from `PolynomialBasis` (if applicable).
- [x] I have implemented all abstract methods (`evaluate_basis`, `fit`, etc.).
- [x] I have used `numpy` vectorization to avoid inefficient Python loops.
- [x] Documentation strings (docstrings) are provided for all public methods.

## Peer Review Checklist (To be completed by Reviewer)

### 1. Mathematical Integrity
- [ ] **Convergence:** Does the implementation maintain expected accuracy? (Checked for Runge's phenomenon or stability).
- [ ] **Edge Cases:** Does it handle single points or non-equally spaced nodes correctly?
- [ ] **Domain Mapping:** Does the class correctly map the input domain to the basis domain (e.g., [-1, 1] for Chebyshev)?

### 2. API & Style
- [ ] **Method Signatures:** Methods match the Abstract Base Class exactly.
- [ ] **Naming:** Follows `CamelCase` for classes and `snake_case` for functions/variables.
- [ ] **Clean Code:** No "magic numbers"; constants are named and explained.

### 3. Testing Quality
- [ ] **Coverage:** Unit tests cover typical usage and edge cases.
- [ ] **Precision:** Tests use `np.testing.assert_allclose` instead of `==`.
- [ ] **Validation:** There is a test proving the basis can exactly reconstruct a polynomial of its own degree.

## Screenshots / Plots