### PR TITLE
Implement L2Projector and tests

### DIFF
--- a/src/numanalysislib/approximation/l2_project.py
+++ b/src/numanalysislib/approximation/l2_project.py
@@ -1,6 +1,7 @@
 import numpy as np
 from typing import Callable
 from numanalysislib.basis._abstract import PolynomialBasis
+from numanalysislib.calculus.integrator import Quadrature
 
 
 class L2Projector:
@@ -13,34 +14,43 @@ class L2Projector:
         b_i  = ∫ f(x) phi_i(x) dx
     """
 
-    def __init__(self, n_quad: int = 1000):
+    def __init__(self, rule: str = "gauss-legendre", n_points: int = 5):
         """
-        Args:
-            n_quad: Number of quadrature points used in the trapezoidal rule.
+        Parameters
+        ----------
+        rule : str, optional
+            Quadrature rule to use.
+        n_points : int, optional
+            Number of quadrature points.
+        Returns
+        -------
+        None
         """
-        self.n_quad = n_quad
-
-    def _integrate(self, f: Callable[[np.ndarray], np.ndarray], a: float, b: float) -> float:
-        """
-        Numerically integrate f over [a, b] using the composite trapezoidal rule.
-        """
-        x = np.linspace(a, b, self.n_quad)
-        y = f(x)
-        return np.trapezoid(y, x)
+        self.integrator = Quadrature(rule = rule, n_points = n_points)
 
     def mass_matrix(self, basis: PolynomialBasis) -> np.ndarray:
         """
         Assemble the mass matrix M with entries
             M_ij = ∫ phi_i(x) phi_j(x) dx
+        Parameters
+        ----------
+        basis : PolynomialBasis
+            Basis object defining the approximation space.
+        Returns
+        -------
+        np.ndarray
+            Mass matrix of shape ``(basis.n_dofs, basis.n_dofs)``.
         """
         M = np.zeros((basis.n_dofs, basis.n_dofs), dtype=float)
 
         for i in range(basis.n_dofs):
-            for j in range(basis.n_dofs):
+            for j in range(i, basis.n_dofs):
                 integrand = lambda x, i=i, j=j: (
                     basis.evaluate_basis(i, x) * basis.evaluate_basis(j, x)
                 )
-                M[i, j] = self._integrate(integrand, basis.a, basis.b)
+                value = self.integrator.integrate(integrand, basis.a, basis.b)
+                M[i, j] = value
+                M[j, i] = value
 
         return M
 
@@ -50,12 +60,22 @@ class L2Projector:
         """
         Assemble the load vector b with entries
             b_i = ∫ f(x) phi_i(x) dx
+        Parameters
+        ----------
+        basis : PolynomialBasis
+            Basis object defining the approximation space.
+        f : Callable[[np.ndarray], np.ndarray]
+            Function to project onto the basis space.
+        Returns
+        -------
+        np.ndarray
+            Load vector of shape ``(basis.n_dofs,)``.
         """
         b = np.zeros(basis.n_dofs, dtype=float)
 
         for i in range(basis.n_dofs):
             integrand = lambda x, i=i: f(x) * basis.evaluate_basis(i, x)
-            b[i] = self._integrate(integrand, basis.a, basis.b)
+            b[i] = self.integrator.integrate(integrand, basis.a, basis.b)
 
         return b
 
@@ -65,6 +85,21 @@ class L2Projector:
         """
         Compute the L2 projection coefficients by solving
             M c = b
+        Parameters
+        ----------
+        basis : PolynomialBasis
+            Basis object defining the approximation space.
+        f : Callable[[np.ndarray], np.ndarray]
+            Function to project onto the basis space.
+        Returns
+        -------
+        np.ndarray
+            Coefficient vector of shape ``(basis.n_dofs,)`` containing the
+            L2 projection of ``f`` onto the span of the basis functions.
+        Raises
+        ------
+        ValueError
+            If the linear system for the projection cannot be solved.
         """
         M = self.mass_matrix(basis)
         b = self.load_vector(basis, f)

--- a/src/numanalysislib/approximation/l2_project.py
+++ b/src/numanalysislib/approximation/l2_project.py
@@ -1,0 +1,77 @@
+import numpy as np
+from typing import Callable
+from numanalysislib.basis._abstract import PolynomialBasis
+
+
+class L2Projector:
+    """
+    Compute the L2 projection of a function onto a polynomial basis space.
+    The projection coefficients c solve:
+        M c = b
+    where
+        M_ij = ∫ phi_i(x) phi_j(x) dx
+        b_i  = ∫ f(x) phi_i(x) dx
+    """
+
+    def __init__(self, n_quad: int = 1000):
+        """
+        Args:
+            n_quad: Number of quadrature points used in the trapezoidal rule.
+        """
+        self.n_quad = n_quad
+
+    def _integrate(self, f: Callable[[np.ndarray], np.ndarray], a: float, b: float) -> float:
+        """
+        Numerically integrate f over [a, b] using the composite trapezoidal rule.
+        """
+        x = np.linspace(a, b, self.n_quad)
+        y = f(x)
+        return np.trapezoid(y, x)
+
+    def mass_matrix(self, basis: PolynomialBasis) -> np.ndarray:
+        """
+        Assemble the mass matrix M with entries
+            M_ij = ∫ phi_i(x) phi_j(x) dx
+        """
+        M = np.zeros((basis.n_dofs, basis.n_dofs), dtype=float)
+
+        for i in range(basis.n_dofs):
+            for j in range(basis.n_dofs):
+                integrand = lambda x, i=i, j=j: (
+                    basis.evaluate_basis(i, x) * basis.evaluate_basis(j, x)
+                )
+                M[i, j] = self._integrate(integrand, basis.a, basis.b)
+
+        return M
+
+    def load_vector(
+        self, basis: PolynomialBasis, f: Callable[[np.ndarray], np.ndarray]
+    ) -> np.ndarray:
+        """
+        Assemble the load vector b with entries
+            b_i = ∫ f(x) phi_i(x) dx
+        """
+        b = np.zeros(basis.n_dofs, dtype=float)
+
+        for i in range(basis.n_dofs):
+            integrand = lambda x, i=i: f(x) * basis.evaluate_basis(i, x)
+            b[i] = self._integrate(integrand, basis.a, basis.b)
+
+        return b
+
+    def project(
+        self, basis: PolynomialBasis, f: Callable[[np.ndarray], np.ndarray]
+    ) -> np.ndarray:
+        """
+        Compute the L2 projection coefficients by solving
+            M c = b
+        """
+        M = self.mass_matrix(basis)
+        b = self.load_vector(basis, f)
+
+        try:
+            coeffs = np.linalg.solve(M, b)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError("Failed to solve the L2 projection system.") from exc
+
+        return coeffs

--- a/tests/test_l2_project.py
+++ b/tests/test_l2_project.py
@@ -1,0 +1,56 @@
+import numpy as np
+from numanalysislib.basis.power import PowerBasis
+from numanalysislib.approximation.l2_project import L2Projector
+
+
+class TestL2Projector:
+
+    def test_initialization(self):
+        projector = L2Projector(n_quad=500)
+        assert projector.n_quad == 500
+
+    def test_mass_matrix_shape(self):
+        basis = PowerBasis(degree=2)
+        projector = L2Projector()
+        M = projector.mass_matrix(basis)
+        assert M.shape == (3, 3)
+
+    def test_mass_matrix_symmetric(self):
+        basis = PowerBasis(degree=2)
+        projector = L2Projector()
+        M = projector.mass_matrix(basis)
+        np.testing.assert_allclose(M, M.T, atol=1e-10)
+
+    def test_load_vector_shape(self):
+        basis = PowerBasis(degree=2)
+        projector = L2Projector()
+        f = lambda x: 1 + x
+        b = projector.load_vector(basis, f)
+        assert b.shape == (3,)
+
+    def test_project_exact_linear_function(self):
+        """
+        Project f(x) = 1 + 2x onto PowerBasis(1).
+        Since f is already in the space span{1, x},
+        the coefficients should be [1, 2].
+        """
+        basis = PowerBasis(degree=1)
+        projector = L2Projector(n_quad=2000)
+
+        f = lambda x: 1 + 2 * x
+        coeffs = projector.project(basis, f)
+
+        expected = np.array([1.0, 2.0])
+        np.testing.assert_allclose(coeffs, expected, atol=1e-4)
+
+    def test_project_constant_function(self):
+        """
+        Project f(x) = 3 onto PowerBasis(1).
+        The exact coefficients should be [3, 0].
+        """
+        basis = PowerBasis(degree=1)
+        projector = L2Projector(n_quad=2000)
+        f = lambda x: 3.0 * np.ones_like(x)
+        coeffs = projector.project(basis, f)
+        expected = np.array([3.0, 0.0])
+        np.testing.assert_allclose(coeffs, expected, atol=1e-4)

--- a/tests/test_l2_project.py
+++ b/tests/test_l2_project.py
@@ -6,8 +6,9 @@ from numanalysislib.approximation.l2_project import L2Projector
 class TestL2Projector:
 
     def test_initialization(self):
-        projector = L2Projector(n_quad=500)
-        assert projector.n_quad == 500
+        projector = L2Projector(rule = "gauss-lobatto", n_points = 10)
+        assert projector.integrator.rule == "gauss-lobatto"
+        assert projector.integrator.n_points == 10
 
     def test_mass_matrix_shape(self):
         basis = PowerBasis(degree=2)
@@ -35,13 +36,13 @@ class TestL2Projector:
         the coefficients should be [1, 2].
         """
         basis = PowerBasis(degree=1)
-        projector = L2Projector(n_quad=2000)
+        projector = L2Projector()
 
         f = lambda x: 1 + 2 * x
         coeffs = projector.project(basis, f)
 
         expected = np.array([1.0, 2.0])
-        np.testing.assert_allclose(coeffs, expected, atol=1e-4)
+        np.testing.assert_allclose(coeffs, expected, atol=1e-6)
 
     def test_project_constant_function(self):
         """
@@ -49,7 +50,7 @@ class TestL2Projector:
         The exact coefficients should be [3, 0].
         """
         basis = PowerBasis(degree=1)
-        projector = L2Projector(n_quad=2000)
+        projector = L2Projector()
         f = lambda x: 3.0 * np.ones_like(x)
         coeffs = projector.project(basis, f)
         expected = np.array([3.0, 0.0])


### PR DESCRIPTION
## Description
This Pull Request implements L2Projector for Task 14

- Assembles the mass matrix M
- Assembles the load vector b
- Solve the system Mc = b to compute projection coefficients

Implementation Details
- Uses composite trapezoidal rule for numerical integration
- 
## Linked Issue
Fixes # 29

## Implementation Checklist
- [ ] My class inherits from `PolynomialBasis` (if applicable).
- [ ] I have implemented all abstract methods (`evaluate_basis`, `fit`, etc.).
- [ ] I have used `numpy` vectorization to avoid inefficient Python loops.
- [ ] Documentation strings (docstrings) are provided for all public methods.

## Peer Review Checklist (To be completed by Reviewer)

### 1. Mathematical Integrity
- [ ] **Convergence:** Does the implementation maintain expected accuracy? (Checked for Runge's phenomenon or stability).
- [ ] **Edge Cases:** Does it handle single points or non-equally spaced nodes correctly?
- [ ] **Domain Mapping:** Does the class correctly map the input domain to the basis domain (e.g., [-1, 1] for Chebyshev)?

### 2. API & Style
- [ ] **Method Signatures:** Methods match the Abstract Base Class exactly.
- [ ] **Naming:** Follows `CamelCase` for classes and `snake_case` for functions/variables.
- [ ] **Clean Code:** No "magic numbers"; constants are named and explained.

### 3. Testing Quality
- [ ] **Coverage:** Unit tests cover typical usage and edge cases.
- [ ] **Precision:** Tests use `np.testing.assert_allclose` instead of `==`.
- [ ] **Validation:** There is a test proving the basis can exactly reconstruct a polynomial of its own degree.

## Screenshots / Plots